### PR TITLE
fix: surface clearer error when token cannot create releases

### DIFF
--- a/.reek.yml
+++ b/.reek.yml
@@ -5,6 +5,7 @@ exclude_paths:
 detectors:
   UncommunicativeVariableName:
     accept:
+      - e
       - f
   IrresponsibleModule:
     enabled: false

--- a/README.md
+++ b/README.md
@@ -107,3 +107,20 @@ The default `GITHUB_TOKEN` does not trigger other workflows when creating tags. 
   with:
     github_token: ${{ secrets.PAT }}
 ```
+
+## Token permissions
+
+Verselicious creates a GitHub Release, which also creates the underlying tag. Whichever token you pass via `github_token` must be allowed to write releases to the target repository. A `404 Not Found` from `POST /repos/{owner}/{repo}/releases` almost always means the token lacks those permissions — GitHub deliberately returns 404 instead of 403 to avoid leaking repository existence.
+
+Use whichever option matches your token type:
+
+- **`secrets.GITHUB_TOKEN`** — the workflow must declare `permissions: contents: write`:
+
+  ```yaml
+  permissions:
+    contents: write
+  ```
+
+- **Classic personal access token** — the token needs the `repo` scope (or `public_repo` if only public repositories are targeted).
+
+- **Fine-grained personal access token** — the token needs the **Contents: Read and write** repository permission, and the token must be granted access to the target repository.

--- a/lib/verselicious/release_creator.rb
+++ b/lib/verselicious/release_creator.rb
@@ -1,7 +1,19 @@
 # frozen_string_literal: true
 
+require 'octokit'
+
 module Verselicious
   class ReleaseCreator
+    PERMISSION_HINT = <<~HINT.strip
+      The token cannot write releases to this repository. Verify the token has the required permissions:
+        - GITHUB_TOKEN: workflow needs `permissions: contents: write`
+        - Classic PAT: `repo` scope (or `public_repo` for public repos only)
+        - Fine-grained PAT: "Contents: Read and write" with access to this repository
+      See the README "Token permissions" section for details.
+    HINT
+
+    class PermissionError < StandardError; end
+
     def initialize(client:, repo:)
       @client = client
       @repo = repo
@@ -15,6 +27,8 @@ module Verselicious
         generate_release_notes: generate_notes,
         name: tag
       )
+    rescue Octokit::NotFound, Octokit::Unauthorized => e
+      raise PermissionError, "Failed to create release for #{@repo} (#{e.class}: #{e.message}). #{PERMISSION_HINT}"
     end
   end
 end

--- a/spec/lib/verselicious/release_creator_spec.rb
+++ b/spec/lib/verselicious/release_creator_spec.rb
@@ -36,5 +36,24 @@ RSpec.describe Verselicious::ReleaseCreator do
       expect(result.html_url).to include('v2.0.0')
       expect(client).to have_received(:create_release)
     end
+
+    it 'raises a PermissionError with hint when GitHub returns 404' do
+      allow(client).to receive(:create_release)
+        .and_raise(Octokit::NotFound.new(status: 404, body: { message: 'Not Found' }))
+
+      expect { creator.create(tag: '1.2.0', target_branch: 'main', generate_notes: true) }
+        .to raise_error(
+          Verselicious::ReleaseCreator::PermissionError,
+          %r{owner/repo.*Octokit::NotFound.*contents: write.*Token permissions}m
+        )
+    end
+
+    it 'raises a PermissionError with hint when GitHub returns 401' do
+      allow(client).to receive(:create_release)
+        .and_raise(Octokit::Unauthorized.new(status: 401, body: { message: 'Bad credentials' }))
+
+      expect { creator.create(tag: '1.2.0', target_branch: 'main', generate_notes: true) }
+        .to raise_error(Verselicious::ReleaseCreator::PermissionError, /Octokit::Unauthorized/)
+    end
   end
 end


### PR DESCRIPTION
## Description

A `404 Not Found` from `POST /repos/{owner}/{repo}/releases` almost always means the token cannot write releases to the repository — GitHub deliberately returns 404 instead of 403 to avoid disclosing repository existence. The action was bubbling this up as a raw `Octokit::NotFound` stacktrace, leaving users guessing.

This PR catches `Octokit::NotFound` and `Octokit::Unauthorized` in `ReleaseCreator#create` and re-raises a `Verselicious::ReleaseCreator::PermissionError` whose message lists the required permissions for each token type:

- `GITHUB_TOKEN` — workflow needs `permissions: contents: write`
- Classic PAT — `repo` scope (or `public_repo` for public repos)
- Fine-grained PAT — "Contents: Read and write" with access to the target repo

The README gains a matching "Token permissions" section so users can find the requirements without parsing the error.

Note: the action does not push a tag separately — `Octokit::Client#create_release` creates the tag and release atomically — so a 404 here leaves nothing behind to roll back.

Closes #21

## How to test/reproduce

```
bundle exec rspec spec/lib/verselicious/release_creator_spec.rb
bundle exec rubocop
```

The two new specs in `spec/lib/verselicious/release_creator_spec.rb` cover the 404 and 401 paths.

## Review checklist

- [x] PR is split into meaningful commits for the ease of reviewing
- [x] Description contains clear instructions on how to test the feature (where applicable)
- [x] Appropriate labels have been applied
- [x] Update [README](../README.md) (where applicable)