### PR TITLE
docs: bump version in quick-start example to 0.2.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - uses: hopeman15/verselicious@v0.1.0
+      - uses: hopeman15/verselicious@v0.2.1
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
 ```


### PR DESCRIPTION
## Description

Bump the `hopeman15/verselicious@vX.Y.Z` reference in the README Quick Start example from `v0.1.0` to `v0.2.1` so new adopters copy a current version rather than the initial release.

## How to test/reproduce

N/A — documentation-only change. Verify by viewing the rendered README and confirming the Quick Start snippet references `@v0.2.1`.

## Review checklist

- [x] PR is split into meaningful commits for the ease of reviewing
- [x] Description contains clear instructions on how to test the feature (where applicable)
- [x] Appropriate labels have been applied
- [x] Update [README](../README.md) (where applicable)